### PR TITLE
Core: Global Usage Endpoints

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -9,8 +9,7 @@ require "rubygpt"
 
 api_key = ENV["OPENAI_SECRET_TOKEN"] # Your OpenAI API key, saved as environment variable
 model = "gpt-3.5-turbo"
-@client = Rubygpt::Client.new(api_key:, model:)
-@chat = Rubygpt::Requester::ChatRequester.new(@client)
+@client = Rubygpt.configure(api_key:, model:)
 
 require "irb"
 IRB.start(__FILE__)

--- a/lib/rubygpt.rb
+++ b/lib/rubygpt.rb
@@ -11,6 +11,24 @@ require_relative "rubygpt/response/chat_completion"
 require_relative "rubygpt/requester"
 require_relative "rubygpt/requester/chat_requester"
 
+# The main module for Rubygpt
+# Contains static methods for configuration
 module Rubygpt
-  class Error < StandardError; end
+  class << self
+    # The default singleton client for the module
+    # Allows a global configuration to be set across the module
+    #
+    # @return [Client]
+    def configure(configuration = nil, &block)
+      @default_client = Client.new(configuration, &block)
+    end
+
+    # A ChatRequester object, configured by default client
+    # Allows the Rubygpt.chat calls
+    #
+    # @return [Requester::ChatRequester]
+    def chat
+      @chat ||= Requester::ChatRequester.new(@default_client)
+    end
+  end
 end

--- a/lib/rubygpt.rb
+++ b/lib/rubygpt.rb
@@ -20,6 +20,7 @@ module Rubygpt
     #
     # @return [Client]
     def configure(configuration = nil, &block)
+      reset_requesters
       @default_client = Client.new(configuration, &block)
     end
 
@@ -29,6 +30,11 @@ module Rubygpt
     # @return [Requester::ChatRequester]
     def chat
       @chat ||= Requester::ChatRequester.new(@default_client)
+    end
+
+    # Remove memoized requester objects to allow reallocation
+    def reset_requesters
+      @chat = nil
     end
   end
 end

--- a/lib/rubygpt/common/message.rb
+++ b/lib/rubygpt/common/message.rb
@@ -40,6 +40,10 @@ module Common
       !!@json_content
     end
 
+    def empty?
+      content.nil? || content.empty?
+    end
+
     def to_h
       { role:, content:, name:, tool_calls:, tool_call_id: }.compact
     end

--- a/spec/lib/requester/chat_requester_spec.rb
+++ b/spec/lib/requester/chat_requester_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Rubygpt::Requester::ChatRequester do
         expect(response).to be_a(Rubygpt::Response::ChatCompletion)
       end
     end
+
+    context "with messages without bodies" do
+      subject(:response) { chat_requester.create }
+
+      it "raises ArgumentError" do
+        expect { response }.to raise_error(ArgumentError, "Empty message contents found.")
+      end
+    end
   end
 
   describe "#create_request_body" do

--- a/spec/lib/requester/chat_requester_spec.rb
+++ b/spec/lib/requester/chat_requester_spec.rb
@@ -67,33 +67,35 @@ RSpec.describe Rubygpt::Requester::ChatRequester do
       end
     end
 
-    context "with hash argument" do
-      context "when messages key present" do
-        let(:args) { { messages: ["Hello, world!", "How are you?"] } }
-
-        it "creates messages for each content with default attributes" do
-          expected_messages = [
-            { role: "system", content: "Hello, world!" },
-            { role: "system", content: "How are you?" }
-          ]
-          expect(messages).to eq(expected_messages)
-        end
-      end
-
-      context "when messages key not present" do
-        let(:args) { { content: "Hello, world!", role: "user" } }
-
-        it "creates a message from hash" do
-          expect(messages).to eq([{ content: "Hello, world!", role: "user" }])
-        end
-      end
-    end
-
     context "with invalid argument" do
       let(:args) { 123 }
 
       it "raises an ArgumentError" do
         expect { messages }.to raise_error(ArgumentError, "Invalid message data provided")
+      end
+    end
+  end
+
+  describe "#messages_from_hash" do
+    subject(:messages) { chat_requester.send(:messages_from_hash, args) }
+
+    context "when messages key present" do
+      let(:args) { { messages: ["Hello, world!", "How are you?"] } }
+
+      it "creates messages for each content with default attributes" do
+        expected_messages = [
+          { role: "system", content: "Hello, world!" },
+          { role: "system", content: "How are you?" }
+        ]
+        expect(messages).to eq(expected_messages)
+      end
+    end
+
+    context "when messages key not present" do
+      let(:args) { { content: "Hello, world!", role: "user" } }
+
+      it "creates a message from hash" do
+        expect(messages).to eq([{ content: "Hello, world!", role: "user" }])
       end
     end
   end

--- a/spec/rubygpt_spec.rb
+++ b/spec/rubygpt_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe Rubygpt do
   it "has a version number" do
     expect(Rubygpt::VERSION).not_to be nil
   end
+
+  describe ".configure" do
+    it "can configure the default client with a block" do
+      Rubygpt.configure do |config|
+        config.api_key = "api-key-block"
+        config.model = "model-block"
+        config.organization_id = "organization-id-block"
+      end
+      client_config = Rubygpt.instance_variable_get(:@default_client).configuration
+      expect(client_config.api_key).to eq("api-key-block")
+      expect(client_config.model).to eq("model-block")
+      expect(client_config.organization_id).to eq("organization-id-block")
+    end
+
+    it "can configure the default client with a hash" do
+      Rubygpt.configure(api_key: "api-key-hash", model: "model-hash", organization_id: "organization-id-hash")
+      client_config = Rubygpt.instance_variable_get(:@default_client).configuration
+      expect(client_config.api_key).to eq("api-key-hash")
+      expect(client_config.model).to eq("model-hash")
+      expect(client_config.organization_id).to eq("organization-id-hash")
+    end
+  end
+
+  describe ".chat" do
+    it "returns a ChatRequester object" do
+      expect(Rubygpt.chat).to be_a(Rubygpt::Requester::ChatRequester)
+      expect(Rubygpt.chat.client).to eq(Rubygpt.instance_variable_get(:@default_client))
+    end
+  end
 end


### PR DESCRIPTION
Writing the static module methods.

Creates endpoints to use the library without the procedure of creating new client/configuration instances.

```ruby
# Creating singleton instances
Rubygpt.configure(api_key:, model:) # #<Rubygpt::Client:0x00000001286117e0>
Rubygpt.chat # #<Rubygpt::Requester::ChatRequester>
```

This PR also sets the tone for upcoming feature APIs.