### PR TITLE
Gemspec Description Format Fix

### DIFF
--- a/rubygpt.gemspec
+++ b/rubygpt.gemspec
@@ -11,10 +11,11 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.summary = "Ruby wrapper for OpenAI's ChatGPT APIs."
-  spec.description = `
+  spec.description = <<~DESC
     This gem aims to provide an easy-to-use Ruby wrapper for all modules of OpenAI's GPT API.
     It is designed to be simple and easy to use, while also providing a high level of customization.
-    It is also aiming to work efficiently in Ruby on Rails applications.`
+    It is also aiming to work efficiently in Ruby on Rails applications.
+  DESC
   spec.homepage = "https://github.com/feapaydin/rubygpt"
   spec.required_ruby_version = ">= 3.2.0"
 


### PR DESCRIPTION
We receive the following error messages whenever we run the gem:

```
sh: -c: line 1: unexpected EOF while looking for matching `''
sh: -c: line 4: syntax error: unexpected end of file
```

This was caused by the description in the gemspec being written inside backtics, instead of heredoc format.